### PR TITLE
Allocate saves on the stack, never using the red zone (or push/pop instructions)

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -148,10 +148,10 @@ static rejit_func compile(dasm_State** d, size_t* sz, rejit_instruction* instrs,
     int errpc=0, pcl=1;
     dasm_growpc(d, 1);
 
-    compile_prolog(d);
+    compile_prolog(d, maxdepth);
     for (i=0; instrs[i].kind; ++i)
         compile_one(d, &instrs[i], &errpc, &pcl, 0, maxdepth, flags);
-    compile_epilog(d);
+    compile_epilog(d, maxdepth);
 
     return link_and_encode(d, sz);
 }

--- a/src/match.c
+++ b/src/match.c
@@ -18,7 +18,7 @@
 
 #define MAXSZ 100
 
-static void compile_one(dasm_State**, rejit_instruction*, int*, int*, int,
+static void compile_one(dasm_State**, rejit_instruction*, int*, int*, int, int,
                         rejit_flags);
 
 #define GROW dasm_growpc(Dst, ++*pcl)
@@ -139,7 +139,7 @@ static void* link_and_encode(dasm_State** d, size_t* sz) {
 }
 
 static rejit_func compile(dasm_State** d, size_t* sz, rejit_instruction* instrs,
-                          rejit_flags flags) {
+                          int maxdepth, rejit_flags flags) {
     int i;
     void* labels[lbl__MAX];
     dasm_setupglobal(d, labels, lbl__MAX);
@@ -150,20 +150,20 @@ static rejit_func compile(dasm_State** d, size_t* sz, rejit_instruction* instrs,
 
     compile_prolog(d);
     for (i=0; instrs[i].kind; ++i)
-        compile_one(d, &instrs[i], &errpc, &pcl, 0, flags);
+        compile_one(d, &instrs[i], &errpc, &pcl, 0, maxdepth, flags);
     compile_epilog(d);
 
     return link_and_encode(d, sz);
 }
 
 rejit_matcher rejit_compile_instrs(rejit_instruction* instrs, int groups,
-                                   rejit_flags flags) {
+                                   int maxdepth, rejit_flags flags) {
     rejit_func func;
     rejit_matcher res;
     size_t sz;
     dasm_State* d;
     dasm_init(&d, DASM_MAXSECTION);
-    func = compile(&d, &sz, instrs, flags);
+    func = compile(&d, &sz, instrs, maxdepth, flags);
     dasm_free(&d);
     res = malloc(sizeof(struct rejit_matcher_type));
     if (!res) return NULL;

--- a/src/misc.c
+++ b/src/misc.c
@@ -5,7 +5,8 @@
 #include "rejit.h"
 
 rejit_matcher rejit_compile(rejit_parse_result res, rejit_flags flags) {
-    return rejit_compile_instrs(res.instrs, res.groups, res.flags | flags);
+    return rejit_compile_instrs(res.instrs, res.groups, res.maxdepth,
+                                res.flags | flags);
 }
 
 rejit_matcher rejit_parse_compile(const char* str, rejit_parse_error* err,

--- a/src/parse.c
+++ b/src/parse.c
@@ -133,6 +133,7 @@ static void build_suffix_pipe_list(const char* str, rejit_token_list tokens,
 
     for (i=0; i<tokens.len; ++i) {
         rejit_token t = tokens.tokens[i];
+
         if (t.kind == RJ_TLP) {
             PUSH(st, i);
             prev = -1;
@@ -243,6 +244,8 @@ static void parse(const char* str, rejit_token_list tokens, long* suffixes,
     for (i=0; i<tokens.len; ++i) {
         rejit_token t = tokens.tokens[i];
         lb_later = 0;
+
+        if (pst.len + st.len > res->maxdepth) res->maxdepth = pst.len + st.len;
 
         if (suffixes[i] != -1) {
             rejit_token st = tokens.tokens[suffixes[i]];
@@ -422,6 +425,7 @@ rejit_parse_result rejit_parse(const char* str, rejit_parse_error* err) {
     rejit_token_list tokens;
     res.instrs = NULL;
     res.groups = 0;
+    res.maxdepth = 0;
     res.flags = RJ_FNONE;
 
     err->kind = RJ_PE_NONE;

--- a/src/rejit.h
+++ b/src/rejit.h
@@ -152,7 +152,7 @@ rejit_parse_result rejit_parse(const char* str, rejit_parse_error* err);
 void rejit_free_parse_result(rejit_parse_result res);
 int rejit_match_len(rejit_instruction* instr);
 rejit_matcher rejit_compile_instrs(rejit_instruction* instrs, int groups,
-                                   rejit_flags flags);
+                                   int maxdepth, rejit_flags flags);
 /*! @function rejit_compile
     @brief Compile the result of calling @link rejit_parse @/link.
 

--- a/src/rejit.h
+++ b/src/rejit.h
@@ -97,7 +97,7 @@ typedef struct rejit_token_list_type {
     @brief The value returned from @link rejit_parse @/link. */
 typedef struct rejit_parse_result_type {
     rejit_instruction* instrs;
-    int groups;
+    int groups, maxdepth;
     rejit_flags flags;
 } rejit_parse_result;
 

--- a/src/x86_64.dasc
+++ b/src/x86_64.dasc
@@ -160,7 +160,7 @@ static void compile_epilog(dasm_State** Dst) {
 }
 
 static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
-                        int* pcl, int saved, rejit_flags flags) {
+                        int* pcl, int saved, int maxdepth, rejit_flags flags) {
     rejit_instruction* ia, *ib, *ic;
     unsigned long magic;
     char min, *s;
@@ -205,7 +205,7 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
     case RJ_IOPT:
         ia = instr+1;
         if (instr->kind == RJ_IPLUS)
-            compile_one(Dst, ia, errpc, pcl, saved, flags);
+            compile_one(Dst, ia, errpc, pcl, saved, maxdepth, flags);
         *errpc = *pcl;
         GROW;
         bk = *pcl;
@@ -213,7 +213,7 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
         if (instr->kind != RJ_IOPT)
             |=>bk:
         if (instr->kind == RJ_IPLUS) unskip(ia);
-        compile_one(Dst, ia, errpc, pcl, saved, flags);
+        compile_one(Dst, ia, errpc, pcl, saved, maxdepth, flags);
         if (instr->kind != RJ_IOPT) {
             // Without the braces here, DynAsm generates incorrect code.
             | jmp =>bk
@@ -224,13 +224,13 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
     case RJ_IREP:
         ia = instr+1;
         for (i=0; i<instr->value; ++i) {
-            compile_one(Dst, ia, errpc, pcl, saved, flags);
+            compile_one(Dst, ia, errpc, pcl, saved, maxdepth, flags);
             unskip(ia);
         }
         *errpc = *pcl;
         GROW;
         for (i=instr->value; i<instr->value2; ++i) {
-            compile_one(Dst, ia, errpc, pcl, saved, flags);
+            compile_one(Dst, ia, errpc, pcl, saved, maxdepth, flags);
             unskip(ia);
         }
         |=>*errpc:
@@ -246,7 +246,7 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
             | jmp =>bk+1
         }
         |=>bk:
-        compile_one(Dst, ia, errpc, pcl, saved, flags);
+        compile_one(Dst, ia, errpc, pcl, saved, maxdepth, flags);
         skip(ia);
         if (instr->kind == RJ_IMSTAR)
             |=>bk+1:
@@ -358,7 +358,7 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
         bk = *pcl-1;
         if (needs_unsave) GROW;
         for (; ia != ib; ++ia) {
-            compile_one(Dst, ia, errpc, pcl, saved+1, flags);
+            compile_one(Dst, ia, errpc, pcl, saved+1, maxdepth, flags);
             skip(ia);
         }
         | jmp =>bk
@@ -366,7 +366,7 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
         | gsave
         *errpc = needs_unsave ? bk+1 : ebk;
         for (; ia != ic; ++ia) {
-            compile_one(Dst, ia, errpc, pcl, saved+1, flags);
+            compile_one(Dst, ia, errpc, pcl, saved+1, maxdepth, flags);
             skip(ia);
         }
         *errpc = ebk;
@@ -416,7 +416,7 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
                 | jl =>bk
         }
         for (; ia != ib; ++ia) {
-            compile_one(Dst, ia, errpc, pcl, saved+1, flags);
+            compile_one(Dst, ia, errpc, pcl, saved+1, maxdepth, flags);
             skip(ia);
         }
         *errpc = ebk;

--- a/src/x86_64.dasc
+++ b/src/x86_64.dasc
@@ -23,47 +23,13 @@
 | .define SP, rsp
 | .define TOS, qword [SP]
 
-| .define RED_ZONE_SIZE, 128 // Number of bytes available in the red zone.
-
-| .macro discard
-| add SP, 8
-| .endmacro
+| .define PTRSIZE, 8
 
 | .macro backup
 | mov SAV, STR
 | .endmacro
 
 | .macro ubackup
-| .endmacro
-
-| .macro save
-|| {
-|| if (saved < RED_ZONE_SIZE/8) {
-|      mov [rsp-8*(saved+1)], STR
-||     needs_unsave = 0;
-|| } else {
-|      push STR
-||     needs_unsave = 1;
-|| }
-|| }
-| .endmacro
-
-| .macro gsave
-|| {
-|| if (needs_unsave)
-|      mov STR, TOS
-|| else
-|      mov STR, [rsp-8*(saved+1)]
-|| }
-| .endmacro
-
-| .macro rstsave
-|| {
-|| if (needs_unsave)
-|       pop STR
-|| else
-|       mov STR, [rsp-8*(saved+1)]
-|| }
 | .endmacro
 
 | .macro longcmp, a, b
@@ -87,9 +53,7 @@
 | .define SP, esp
 | .define TOS, dword [SP]
 
-| .macro discard
-| add SP, 4
-| .endmacro
+| .define PTRSIZE, 4
 
 | .macro backup
 | push edi
@@ -109,21 +73,6 @@
 | pop edi
 | .endmacro
 
-| .macro save
-|| {
-|| needs_unsave = 1;
-|  push STR
-|| }
-| .endmacro
-
-| .macro gsave
-|  mov STR, TOS
-| .endmacro
-
-| .macro rstsave
-| pop STR
-| .endmacro
-
 | .macro longcmp, a, b
 | cmp dword a, b
 | .endmacro
@@ -136,25 +85,42 @@
 
 | .define CONST, eax
 
-| .macro unsave
-|| if (needs_unsave)
-|      discard
+| .define SAVPOS, [SP+PTRSIZE*saved]
+
+| .macro save
+|  mov SAVPOS, STR
+| .endmacro
+
+| .macro rstsave
+|  mov STR, SAVPOS
+| .endmacro
+
+| .macro discard
+|  add SP, PTRSIZE
 | .endmacro
 
 | .type group, rejit_group
 
-static void compile_prolog(dasm_State** Dst) {
+static void compile_prolog(dasm_State** Dst, int maxdepth) {
     | backup
     | mov CONST, 1025
+    if (maxdepth)
+        | sub SP, maxdepth*PTRSIZE
 }
 
-static void compile_epilog(dasm_State** Dst) {
+static void compile_epilog(dasm_State** Dst, int maxdepth) {
     | mov RET, STR
     | sub RET, SAV
+    if (maxdepth) {
+        | add SP, maxdepth*PTRSIZE
+    }
     | ubackup
     | ret
     |=>0:
     | mov RET, -1
+    if (maxdepth) {
+        | add SP, maxdepth*PTRSIZE
+    }
     | ubackup
     | ret
 }
@@ -164,7 +130,7 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
     rejit_instruction* ia, *ib, *ic;
     unsigned long magic;
     char min, *s;
-    int ebk = *errpc, bk, i, needs_unsave;
+    int ebk = *errpc, bk, i;
     size_t len;
     if (instr->kind > RJ_ISKIP) return;
     switch (instr->kind) {
@@ -356,28 +322,27 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
         GROW;
         GROW;
         bk = *pcl-1;
-        if (needs_unsave) GROW;
+        /* XXX if (needs_unsave) */ GROW;
         for (; ia != ib; ++ia) {
             compile_one(Dst, ia, errpc, pcl, saved+1, maxdepth, flags);
             skip(ia);
         }
         | jmp =>bk
         |=>*errpc:
-        | gsave
-        *errpc = needs_unsave ? bk+1 : ebk;
+        | rstsave
+        *errpc = /* XXX needs_unsave ? */ bk+1 /* : ebk */;
         for (; ia != ic; ++ia) {
             compile_one(Dst, ia, errpc, pcl, saved+1, maxdepth, flags);
             skip(ia);
         }
         *errpc = ebk;
-        if (needs_unsave) {
+        // if (needs_unsave) {
             | jmp =>bk
             |=>bk+1:
             | rstsave
             | jmp =>*errpc
-        }
+        // }
         |=>bk:
-        | unsave
         break;
     case RJ_ICGROUP:
     case RJ_IGROUP:
@@ -433,22 +398,13 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
             | jmp =>*errpc
             |=>bk+1:
         }
-        if (instr->kind == RJ_ICGROUP) {
-            if (needs_unsave)
-                | mov TMPL0, TOS
-            else {
-                | .if X64
-                | mov TMPL0, [SP-8*(saved+1)]
-                | .else
-                || printf("needs_unsave should be true on X86\n"); abort();
-                | .endif
-            }
-        }
+        if (instr->kind == RJ_ICGROUP)
+            | mov TMPL0, SAVPOS
 
         if (instr->kind == RJ_ILAHEAD || instr->kind == RJ_ILBEHIND)
             | rstsave
         else if (instr->kind != RJ_INLAHEAD && instr->kind != RJ_INLBEHIND && !i)
-            | unsave
+            (void)0; // XXX
 
         if (instr->kind == RJ_ICGROUP) {
             | mov group:GR[instr->value2].begin, TMPL0

--- a/src/x86_64.dasc
+++ b/src/x86_64.dasc
@@ -322,7 +322,6 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
         GROW;
         GROW;
         bk = *pcl-1;
-        /* XXX if (needs_unsave) */ GROW;
         for (; ia != ib; ++ia) {
             compile_one(Dst, ia, errpc, pcl, saved+1, maxdepth, flags);
             skip(ia);
@@ -330,18 +329,11 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
         | jmp =>bk
         |=>*errpc:
         | rstsave
-        *errpc = /* XXX needs_unsave ? */ bk+1 /* : ebk */;
+        *errpc = ebk;
         for (; ia != ic; ++ia) {
             compile_one(Dst, ia, errpc, pcl, saved+1, maxdepth, flags);
             skip(ia);
         }
-        *errpc = ebk;
-        // if (needs_unsave) {
-            | jmp =>bk
-            |=>bk+1:
-            | rstsave
-            | jmp =>*errpc
-        // }
         |=>bk:
         break;
     case RJ_ICGROUP:

--- a/src/x86_64.dasc
+++ b/src/x86_64.dasc
@@ -390,15 +390,12 @@ static void compile_one(dasm_State** Dst, rejit_instruction* instr, int* errpc,
             | jmp =>*errpc
             |=>bk+1:
         }
-        if (instr->kind == RJ_ICGROUP)
-            | mov TMPL0, SAVPOS
 
         if (instr->kind == RJ_ILAHEAD || instr->kind == RJ_ILBEHIND)
             | rstsave
-        else if (instr->kind != RJ_INLAHEAD && instr->kind != RJ_INLBEHIND && !i)
-            (void)0; // XXX
 
         if (instr->kind == RJ_ICGROUP) {
+            | mov TMPL0, SAVPOS
             | mov group:GR[instr->value2].begin, TMPL0
             | mov group:GR[instr->value2].end, STR
         }

--- a/tst.c
+++ b/tst.c
@@ -70,6 +70,8 @@ LIBCUT_TEST(test_parse_word) {
     rejit_parse_result res;
     PARSE("ab")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_IWORD);
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value, "ab");
 
@@ -80,6 +82,8 @@ LIBCUT_TEST(test_parse_suffix) {
     rejit_parse_error err;
     rejit_parse_result res;
     PARSE("ab+")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_IPLUS);
 
@@ -98,6 +102,8 @@ LIBCUT_TEST(test_parse_suffix) {
     LIBCUT_TEST_EQ(res.instrs[2].kind, RJ_INULL);
 
     PARSE("a(?:b?)")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 1);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_IWORD);
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value, "a");
@@ -122,6 +128,8 @@ LIBCUT_TEST(test_parse_suffix) {
     LIBCUT_TEST_EQ(res.instrs[2].kind, RJ_INULL);
 
     PARSE("a{2}")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_IREP);
     LIBCUT_TEST_EQ(res.instrs[0].value, 2);
@@ -154,6 +162,8 @@ LIBCUT_TEST(test_parse_group) {
     rejit_parse_result res;
     PARSE("(ab?)")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 1);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_ICGROUP);
     LIBCUT_TEST_EQ((void*)res.instrs[0].value, (void*)&res.instrs[3]);
 
@@ -165,6 +175,8 @@ LIBCUT_TEST(test_parse_group) {
     LIBCUT_TEST_EQ(res.instrs[3].kind, RJ_INULL);
 
     PARSE("(?:ab?)")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 1);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_IGROUP);
     LIBCUT_TEST_EQ((void*)res.instrs[0].value, (void*)&res.instrs[3]);
@@ -191,17 +203,23 @@ LIBCUT_TEST(test_parse_set) {
 
     PARSE("[abc]")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_ISET);
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value, "abc");
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value+4, "   ");
 
     PARSE("[^abc]")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_INSET);
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value, "abc");
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value+4, "   ");
 
     PARSE("[a-z0-9]")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_ISET);
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value,
@@ -211,6 +229,8 @@ LIBCUT_TEST(test_parse_set) {
 
     PARSE("\\w")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_ISET);
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value,
                       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -218,12 +238,16 @@ LIBCUT_TEST(test_parse_set) {
 
     PARSE("\\W")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_INSET);
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value,
                       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
                       "0123456789_");
 
     PARSE("[^a-z0-9]")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_INSET);
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value,
@@ -246,6 +270,8 @@ LIBCUT_TEST(test_parse_pipe) {
 
     PARSE("a|b")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 1);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_IOR);
     LIBCUT_TEST_EQ(res.instrs[0].value, (intptr_t)&res.instrs[2]);
     LIBCUT_TEST_EQ(res.instrs[0].value2, (intptr_t)&res.instrs[3]);
@@ -259,6 +285,8 @@ LIBCUT_TEST(test_parse_pipe) {
     LIBCUT_TEST_EQ(res.instrs[3].kind, RJ_INULL);
 
     PARSE("a|(b|c)")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 3);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_IOR);
     LIBCUT_TEST_EQ((void*)res.instrs[0].value, (void*)&res.instrs[2]);
@@ -289,6 +317,8 @@ LIBCUT_TEST(test_parse_lookahead) {
 
     PARSE("(?=ab)")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 1);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_ILAHEAD);
     LIBCUT_TEST_EQ((void*)res.instrs[0].value, (void*)&res.instrs[2]);
 
@@ -298,6 +328,8 @@ LIBCUT_TEST(test_parse_lookahead) {
     LIBCUT_TEST_EQ(res.instrs[2].kind, RJ_INULL);
 
     PARSE("(?!ab)")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 1);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_INLAHEAD);
     LIBCUT_TEST_EQ((void*)res.instrs[0].value, (void*)&res.instrs[2]);
@@ -314,6 +346,8 @@ LIBCUT_TEST(test_parse_lookbehind) {
 
     PARSE("(?<=ab)")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 1);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_ILBEHIND);
     LIBCUT_TEST_EQ((void*)res.instrs[0].value, (void*)&res.instrs[2]);
 
@@ -323,6 +357,8 @@ LIBCUT_TEST(test_parse_lookbehind) {
     LIBCUT_TEST_EQ(res.instrs[2].kind, RJ_INULL);
 
     PARSE("(?<!ab)")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 1);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_INLBEHIND);
     LIBCUT_TEST_EQ((void*)res.instrs[0].value, (void*)&res.instrs[2]);
@@ -343,6 +379,8 @@ LIBCUT_TEST(test_parse_other) {
 
     PARSE("^a.b$")
 
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
+
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_IBEGIN);
 
     LIBCUT_TEST_EQ(res.instrs[1].kind, RJ_IWORD);
@@ -358,6 +396,8 @@ LIBCUT_TEST(test_parse_other) {
     LIBCUT_TEST_EQ(res.instrs[5].kind, RJ_INULL);
 
     PARSE("a\\1\\5b")
+
+    LIBCUT_TEST_EQ(res.maxdepth, 0);
 
     LIBCUT_TEST_EQ(res.instrs[0].kind, RJ_IWORD);
     LIBCUT_TEST_STREQ((char*)res.instrs[0].value, "a");

--- a/tst.c
+++ b/tst.c
@@ -417,7 +417,7 @@ LIBCUT_TEST(test_parse_other) {
 LIBCUT_TEST(test_chr) {
     // ca
     rejit_instruction instrs[] = {{RJ_IWORD, (intptr_t)"ca"}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "ca", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "", NULL), -1);
     LIBCUT_TEST_EQ(rejit_match(m, "c", NULL), -1);
@@ -428,7 +428,7 @@ LIBCUT_TEST(test_chr) {
 LIBCUT_TEST(test_dot) {
     // .
     rejit_instruction instrs[] = {{RJ_IDOT}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "c", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "\n", NULL), -1);
@@ -440,7 +440,7 @@ LIBCUT_TEST(test_plus) {
     rejit_instruction instrs[] = {{RJ_IPLUS}, {RJ_IWORD, (intptr_t)"c"},
                                   {RJ_INULL}};
     instrs[0].value = (intptr_t)&instrs[1];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "c", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), -1);
     LIBCUT_TEST_EQ(rejit_match(m, "cc", NULL), 2);
@@ -450,7 +450,7 @@ LIBCUT_TEST(test_star) {
     // c*
     rejit_instruction instrs[] = {{RJ_ISTAR}, {RJ_IWORD, (intptr_t)"c"},
                                   {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "c", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), 0);
     LIBCUT_TEST_EQ(rejit_match(m, "cc", NULL), 2);
@@ -462,7 +462,7 @@ LIBCUT_TEST(test_opt) {
     rejit_instruction instrs[] = {{RJ_IWORD, (intptr_t)"a"}, {RJ_IOPT},
                                   {RJ_IWORD, (intptr_t)"c"}, {RJ_IEND},
                                   {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "ac", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "g", NULL), -1);
@@ -473,7 +473,7 @@ LIBCUT_TEST(test_rep) {
     // a{2,5}$
     rejit_instruction instrs[] = {{RJ_IREP, 2, 5}, {RJ_IWORD, (intptr_t)"a"},
                                   {RJ_IEND}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "aa", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "aaa", NULL), 3);
     LIBCUT_TEST_EQ(rejit_match(m, "aaaa", NULL), 4);
@@ -487,7 +487,7 @@ LIBCUT_TEST(test_begin) {
     // c*^
     rejit_instruction instrs[] = {{RJ_ISTAR}, {RJ_IWORD, (intptr_t)"c"},
                                   {RJ_IBEGIN}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "", NULL), 0);
     LIBCUT_TEST_EQ(rejit_match(m, "c", NULL), -1);
 }
@@ -495,7 +495,7 @@ LIBCUT_TEST(test_begin) {
 LIBCUT_TEST(test_end) {
     // $
     rejit_instruction instrs[] = {{RJ_IEND}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "", NULL), 0);
     LIBCUT_TEST_EQ(rejit_match(m, "c", NULL), -1);
 }
@@ -504,7 +504,7 @@ LIBCUT_TEST(test_set) {
     // [xyz]
     char s[] = "\txyz\0    ";
     rejit_instruction instrs[] = {{RJ_ISET, (intptr_t)s}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "\t", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "x", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "y", NULL), 1);
@@ -517,7 +517,7 @@ LIBCUT_TEST(test_nset) {
     // [^xyz]
     char s[] = "\txyz\0    ";
     rejit_instruction instrs[] = {{RJ_INSET, (intptr_t)s}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "\t", NULL), -1);
     LIBCUT_TEST_EQ(rejit_match(m, "x", NULL), -1);
     LIBCUT_TEST_EQ(rejit_match(m, "y", NULL), -1);
@@ -532,7 +532,7 @@ LIBCUT_TEST(test_or) {
                                   {RJ_IWORD, (intptr_t)"b"}, {RJ_INULL}};
     instrs[0].value = (intptr_t)&instrs[2];
     instrs[0].value2 = (intptr_t)&instrs[3];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "b", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "", NULL), -1);
@@ -543,7 +543,7 @@ LIBCUT_TEST(test_group) {
     rejit_instruction instrs[] = {{RJ_IGROUP}, {RJ_IWORD, (intptr_t)"a"},
                                   {RJ_INULL}};
     instrs[0].value = (intptr_t)&instrs[2];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "", NULL), -1);
 }
@@ -556,7 +556,7 @@ LIBCUT_TEST(test_cgroup) {
                                   {RJ_IOPT}, {RJ_ICGROUP, 0, 1},
                                   {RJ_IWORD, (intptr_t)"b"}, {RJ_INULL}};
     instrs[0].value = instrs[3].value = (intptr_t)&instrs[5];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 2, RJ_FNONE);
 
     memset(groups, 0, sizeof(groups));
     LIBCUT_TEST_EQ(rejit_match(m, str1, groups), 1);
@@ -585,7 +585,7 @@ LIBCUT_TEST(test_opt_group) {
     rejit_instruction instrs[] = {{RJ_IOPT}, {RJ_IGROUP},
                                   {RJ_IWORD, (intptr_t)"ab"}, {RJ_INULL}};
     instrs[1].value = (intptr_t)&instrs[3];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "ab", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), 0);
     LIBCUT_TEST_EQ(rejit_match(m, "b", NULL), 0);
@@ -597,7 +597,7 @@ LIBCUT_TEST(test_star_group) {
     rejit_instruction instrs[] = {{RJ_ISTAR}, {RJ_IGROUP},
                                   {RJ_IWORD, (intptr_t)"ab"}, {RJ_INULL}};
     instrs[1].value = (intptr_t)&instrs[3];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "ab", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "abab", NULL), 4);
     LIBCUT_TEST_EQ(rejit_match(m, "ababab", NULL), 6);
@@ -611,7 +611,7 @@ LIBCUT_TEST(test_plus_group) {
     rejit_instruction instrs[] = {{RJ_IPLUS}, {RJ_IGROUP},
                                   {RJ_IWORD, (intptr_t)"ab"}, {RJ_INULL}};
     instrs[1].value = (intptr_t)&instrs[3];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "ab", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "abab", NULL), 4);
     LIBCUT_TEST_EQ(rejit_match(m, "ababab", NULL), 6);
@@ -628,7 +628,7 @@ LIBCUT_TEST(test_lookahead) {
                                   {RJ_INULL}};
     instrs[0].value = (intptr_t)&instrs[2];
     instrs[4].value = (intptr_t)&instrs[6];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "ab", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "abc", NULL), 3);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), -1);
@@ -641,7 +641,7 @@ LIBCUT_TEST(test_negative_lookahead) {
     rejit_instruction instrs[] = {{RJ_INLAHEAD}, {RJ_IWORD, (intptr_t)"ab"},
                                   {RJ_ISTAR}, {RJ_ISET, (intptr_t)s}, {RJ_INULL}};
     instrs[0].value = (intptr_t)&instrs[2];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "bb", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "aa", NULL), 2);
@@ -655,7 +655,7 @@ LIBCUT_TEST(test_lookbehind) {
                                   {RJ_ILBEHIND}, {RJ_IWORD, (intptr_t)"a", 0, 1},
                                   {RJ_IWORD, (intptr_t)"bc"}, {RJ_INULL}};
     instrs[2].value = (intptr_t)&instrs[4];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "aabc", NULL), 4);
     LIBCUT_TEST_EQ(rejit_match(m, "abc", NULL), 3);
     LIBCUT_TEST_EQ(rejit_match(m, "bc", NULL), -1);
@@ -669,7 +669,7 @@ LIBCUT_TEST(test_negative_lookbehind) {
                                   {RJ_INLBEHIND}, {RJ_IWORD, (intptr_t)"a", 0, 1},
                                   {RJ_IWORD, (intptr_t)"c"}, {RJ_INULL}};
     instrs[2].value = (intptr_t)&instrs[4];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "aaabc", NULL), 5);
     LIBCUT_TEST_EQ(rejit_match(m, "bc", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "ac", NULL), -1);
@@ -680,7 +680,7 @@ LIBCUT_TEST(test_mplus) {
     // .+?b
     rejit_instruction instrs[] = {{RJ_IMPLUS}, {RJ_IDOT},
                                   {RJ_IWORD, (intptr_t)"b"}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "abcb", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "b", NULL), -1);
     LIBCUT_TEST_EQ(rejit_match(m, "abb", NULL), 2);
@@ -691,7 +691,7 @@ LIBCUT_TEST(test_mstar) {
     // .*?b
     rejit_instruction instrs[] = {{RJ_IMSTAR}, {RJ_IDOT},
                                   {RJ_IWORD, (intptr_t)"b"}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "abcb", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "b", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "abb", NULL), 2);
@@ -704,7 +704,7 @@ LIBCUT_TEST(test_or_mixed) {
                                   {RJ_IWORD, (intptr_t)"a"}, {RJ_INULL}};
     instrs[0].value = (intptr_t)&instrs[2];
     instrs[0].value2 = (intptr_t)&instrs[4];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 2, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "aaaa", NULL), 4);
     LIBCUT_TEST_EQ(rejit_match(m, "b", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "", NULL), 0);
@@ -713,7 +713,7 @@ LIBCUT_TEST(test_or_mixed) {
 LIBCUT_TEST(test_search) {
     // a
     rejit_instruction instrs[] = {{RJ_IWORD, (intptr_t)"a"}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     const char* tgt;
     LIBCUT_TEST_EQ(rejit_search(m, "abc", &tgt, NULL), 1);
     LIBCUT_TEST_EQ(*tgt, 'c');
@@ -759,7 +759,7 @@ LIBCUT_TEST(test_set_and_dot) {
     char s[] = "abc\0   ";
     rejit_instruction instrs[] = {{RJ_ISET, (intptr_t)s}, {RJ_IDOT},
                                   {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "ad", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "bd", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "cd", NULL), 2);
@@ -776,7 +776,7 @@ LIBCUT_TEST(test_or_group) {
                                   {RJ_IWORD, (intptr_t)"c"}, {RJ_INULL}};
     instrs[0].value = instrs[1].value = (intptr_t)&instrs[3];
     instrs[0].value2 = (intptr_t)&instrs[4];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 2, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "ab", NULL), 2);
     LIBCUT_TEST_EQ(rejit_match(m, "c", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "ac", NULL), -1);
@@ -791,7 +791,7 @@ LIBCUT_TEST(test_back) {
                                   {RJ_IWORD, (intptr_t)"e"}, {RJ_INULL}};
     rejit_group group;
     instrs[0].value = (intptr_t)&instrs[2];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "abcdabce", &group), 8);
     LIBCUT_TEST_EQ(rejit_match(m, "abcdabe", &group), -1);
     LIBCUT_TEST_EQ(rejit_match(m, "abdabe", &group), -1);
@@ -801,7 +801,7 @@ LIBCUT_TEST(test_back) {
 
 LIBCUT_TEST(test_dotall) {
     rejit_instruction instrs[] = {{RJ_IDOT}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FDOTALL);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FDOTALL);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "\n", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "", NULL), -1);
@@ -809,7 +809,7 @@ LIBCUT_TEST(test_dotall) {
 
 LIBCUT_TEST(test_icase_word) {
     rejit_instruction instrs[] = {{RJ_IWORD, (intptr_t)"aBCd"}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FICASE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FICASE);
     LIBCUT_TEST_EQ(rejit_match(m, "abcd", NULL), 4);
     LIBCUT_TEST_EQ(rejit_match(m, "Abcd", NULL), 4);
     LIBCUT_TEST_EQ(rejit_match(m, "aBcd", NULL), 4);
@@ -827,7 +827,7 @@ LIBCUT_TEST(test_icase_word) {
 LIBCUT_TEST(test_icase_set) {
     char s[] = "abcd\0    ";
     rejit_instruction instrs[] = {{RJ_ISET, (intptr_t)s}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FICASE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FICASE);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "A", NULL), 1);
     LIBCUT_TEST_EQ(rejit_match(m, "b", NULL), 1);
@@ -842,13 +842,13 @@ LIBCUT_TEST(test_save) {
     rejit_instruction instrs[] = {{RJ_IWORD, (intptr_t)"a"}, {RJ_ILBEHIND},
                                   {RJ_IBEGIN}, {RJ_INULL}};
     instrs[1].value = (intptr_t)&instrs[3];
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 1, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "a", NULL), -1);
 }
 
 LIBCUT_TEST(test_long_word) {
     rejit_instruction instrs[] = {{RJ_IWORD, (intptr_t)"abcdefghij"}, {RJ_INULL}};
-    rejit_matcher m = rejit_compile_instrs(instrs, 0, RJ_FNONE);
+    rejit_matcher m = rejit_compile_instrs(instrs, 0, 0, RJ_FNONE);
     LIBCUT_TEST_EQ(rejit_match(m, "abcdefghij", NULL), 10);
     LIBCUT_TEST_EQ(rejit_match(m, "abcdefghi", NULL), -1);
     LIBCUT_TEST_EQ(rejit_match(m, "abcdefghijk", NULL), 10);


### PR DESCRIPTION
Closes #6 and un-blocks #4.
